### PR TITLE
Add to library language fix

### DIFF
--- a/core/tmdb.py
+++ b/core/tmdb.py
@@ -358,7 +358,7 @@ def find_and_set_infoLabels(item):
 
     if item.contentType == "movie":
         tipo_busqueda = "movie"
-        tipo_contenido = "pelicula"
+        tipo_contenido = "film"
         title = item.contentTitle
     else:
         tipo_busqueda = "tv"
@@ -386,7 +386,7 @@ def find_and_set_infoLabels(item):
     if len(results) > 1:
         from platformcode import platformtools
         tmdb_result = platformtools.show_video_info(results, item=item,
-                                                    caption="[%s]: Selecciona la %s correcta" % (title, tipo_contenido))
+                                                    caption="[%s]: Seleziona %s corretto/a" % (title, tipo_contenido))
     elif len(results) > 0:
         tmdb_result = results[0]
 

--- a/core/tmdb.py
+++ b/core/tmdb.py
@@ -358,13 +358,11 @@ def find_and_set_infoLabels(item):
 
     if item.contentType == "movie":
         tipo_busqueda = "movie"
-        tipo_contenido = "film"
-        tipo_conferma = "corretto"
+        tipo_contenido = "pelicula"
         title = item.contentTitle
     else:
         tipo_busqueda = "tv"
         tipo_contenido = "serie"
-        tipo_conferma = "corretta"
         title = item.contentSerieName
 
     # Si el titulo incluye el (año) se lo quitamos
@@ -387,8 +385,12 @@ def find_and_set_infoLabels(item):
 
     if len(results) > 1:
         from platformcode import platformtools
-        tmdb_result = platformtools.show_video_info(results, item=item,
-                                                    caption="[%s]: Seleziona %s %s" % (title, tipo_contenido, tipo_conferma))
+        if tipo_contenido == "pelicula":
+            tmdb_result = platformtools.show_video_info(results, item=item,
+                                                    caption="[%s]: Seleziona il film corretto" % (title))
+        else:
+            tmdb_result = platformtools.show_video_info(results, item=item,
+                                                    caption="[%s]: Seleziona la serie TV corretta" % (title))
     elif len(results) > 0:
         tmdb_result = results[0]
 

--- a/core/tmdb.py
+++ b/core/tmdb.py
@@ -359,10 +359,12 @@ def find_and_set_infoLabels(item):
     if item.contentType == "movie":
         tipo_busqueda = "movie"
         tipo_contenido = "film"
+        tipo_conferma = "corretto"
         title = item.contentTitle
     else:
         tipo_busqueda = "tv"
         tipo_contenido = "serie"
+        tipo_conferma = "corretta"
         title = item.contentSerieName
 
     # Si el titulo incluye el (año) se lo quitamos
@@ -386,7 +388,7 @@ def find_and_set_infoLabels(item):
     if len(results) > 1:
         from platformcode import platformtools
         tmdb_result = platformtools.show_video_info(results, item=item,
-                                                    caption="[%s]: Seleziona %s corretto/a" % (title, tipo_contenido))
+                                                    caption="[%s]: Seleziona %s %s" % (title, tipo_contenido, tipo_conferma))
     elif len(results) > 0:
         tmdb_result = results[0]
 

--- a/platformcode/xbmc_info_window.py
+++ b/platformcode/xbmc_info_window.py
@@ -150,7 +150,7 @@ class InfoWindow(xbmcgui.WindowXMLDialog):
             self.getControl(10007).setLabel(self.result.get("title", "N/A"))
             self.getControl(10008).setLabel("Titolo Or.:")
             self.getControl(10009).setLabel(self.result.get("originaltitle", "N/A"))
-            self.getControl(100010).setLabel("Idioma original:")
+            self.getControl(100010).setLabel("Lingua Or:")
             self.getControl(100011).setLabel(self.result.get("language", "N/A"))
             self.getControl(100012).setLabel("Punteggio:")
             self.getControl(100013).setLabel(self.result.get("puntuacion", "N/A"))


### PR DESCRIPTION
Il form di aggiunta a libreria aveva (ancora) l'header in spagnolo, e un refuso nella label che usava ancora "idioma original" invece di "lingua originale".

Da:
![Imgur](http://i.imgur.com/VdU02Sp.png)

A:
(Per film)
![Imgur](http://i.imgur.com/m9UqeNW.png)

(Per serie TV)
![Imgur](http://i.imgur.com/XM61Mhk.png)